### PR TITLE
Add compatibility with jitpack.io

### DIFF
--- a/NexEngine/pom.xml
+++ b/NexEngine/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/NexEngine/pom.xml
+++ b/NexEngine/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>NexEngine</artifactId>
 
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>1.16</maven.compiler.source>
+        <maven.compiler.target>1.16</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/NexEngine/pom.xml
+++ b/NexEngine/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>NexEngine</artifactId>
 
     <properties>
-        <maven.compiler.source>1.16</maven.compiler.source>
-        <maven.compiler.target>1.16</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/NexEngine/pom.xml
+++ b/NexEngine/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
-        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/PlayerBlockTracker/pom.xml
+++ b/PlayerBlockTracker/pom.xml
@@ -14,8 +14,9 @@
     <version>1.0.1</version>
 
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>1.16</maven.compiler.source>
+        <maven.compiler.target>1.16</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/PlayerBlockTracker/pom.xml
+++ b/PlayerBlockTracker/pom.xml
@@ -9,13 +9,12 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>su.nexmedia.playerblocktracker</groupId>
     <artifactId>PlayerBlockTracker</artifactId>
     <version>1.0.1</version>
 
     <properties>
-        <maven.compiler.source>1.16</maven.compiler.source>
-        <maven.compiler.target>1.16</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/PlayerBlockTracker/pom.xml
+++ b/PlayerBlockTracker/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
-        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/PlayerBlockTracker/pom.xml
+++ b/PlayerBlockTracker/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/PlayerBlockTracker/pom.xml
+++ b/PlayerBlockTracker/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>su.nexmedia.playerblocktracker</groupId>
     <artifactId>PlayerBlockTracker</artifactId>
     <version>1.0.1</version>
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk16

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,5 @@
 jdk:
   - openjdk16
+before_install:
+  - sdk install java 16.0.2-open
+  - sdk use java 16.0.2-open

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>1.16</maven.compiler.source>
-        <maven.compiler.target>1.16</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
-        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,9 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>1.16</maven.compiler.source>
+        <maven.compiler.target>1.16</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
This PR allows NexEngine to be used as a Maven dependency through jitpack.io

i.e
```
	<dependency>
	    <groupId>com.github.nulli0n</groupId>
	    <artifactId>NexEngine-spigot</artifactId>
	    <version>v2.2.11</version>
	</dependency>```

Edit: The intention is to make ExcellentCrates also usable through Jitpack, but this dependency must be accessible through Maven first.